### PR TITLE
Make package compatible with php version 8. Extending Stack.php over…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,29 @@
 {
-  "name": "chroma-x/stack-util",
-  "type": "library",
-  "description": "A PHP library providing common stack implementation.",
-  "keywords": [
-    "stack"
-  ],
-  "homepage": "http://chroma-x.de/",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Martin Brecht-Precht",
-      "email": "mb@chroma-x.de",
-      "homepage": "http://chroma-x.de"
-    }
-  ],
-  "autoload": {
-    "psr-4": {
-      "ChromaX\\StackUtil\\": "src/"
-    }
-  },
-  "require": {
-    "php": ">=5.3"
-  },
-  "require-dev": {
-    "phpunit/phpunit": ">=4.8.26",
-    "codeclimate/php-test-reporter": "dev-master"
-  }
+	"name": "chroma-x/stack-util",
+	"type": "library",
+	"description": "A PHP library providing common stack implementation.",
+	"keywords": [
+		"stack"
+	],
+	"homepage": "https://chroma-x.de/",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Martin Brecht-Precht",
+			"email": "mb@chroma-x.de",
+			"homepage": "https://chroma-x.de"
+		}
+	],
+	"autoload": {
+		"psr-4": {
+			"ChromaX\\StackUtil\\": "src/"
+		}
+	},
+	"require": {
+		"php": ">=5.3"
+	},
+	"require-dev": {
+		"phpunit/phpunit": ">=4.8.26",
+		"codeclimate/php-test-reporter": "dev-master"
+	}
 }

--- a/src/Stack.php
+++ b/src/Stack.php
@@ -100,6 +100,7 @@ class Stack implements StackInterface
 	 * @link http://php.net/manual/en/iterator.current.php
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		return $this->items[$this->cursor];
@@ -111,6 +112,7 @@ class Stack implements StackInterface
 	 * @link http://php.net/manual/en/iterator.next.php
 	 * @return void
 	 */
+	#[\ReturnTypeWillChange]
 	public function next()
 	{
 		++$this->cursor;
@@ -122,6 +124,7 @@ class Stack implements StackInterface
 	 * @link http://php.net/manual/en/iterator.key.php
 	 * @return mixed scalar on success, or null on failure.
 	 */
+	#[\ReturnTypeWillChange]
 	public function key()
 	{
 		return $this->cursor;
@@ -133,6 +136,7 @@ class Stack implements StackInterface
 	 * @link http://php.net/manual/en/iterator.valid.php
 	 * @return boolean
 	 */
+	#[\ReturnTypeWillChange]
 	public function valid()
 	{
 		return isset($this->items[$this->cursor]);
@@ -144,6 +148,7 @@ class Stack implements StackInterface
 	 * @link http://php.net/manual/en/iterator.rewind.php
 	 * @return void
 	 */
+	#[\ReturnTypeWillChange]
 	public function rewind()
 	{
 		$this->cursor = 0;


### PR DESCRIPTION
I made a package compatible with php version > 8.1. I extended Stack.php overriding methods with a compatible return type. Because we need to maintain compatibility with older versions, I added an attribute to silence deprecation notices for PHP version > 8.1 instead of adding return types, which are not available in older versions. 

More information - https://www.php.net/manual/en/class.returntypewillchange.php